### PR TITLE
fix(api): Corrigindo implementação do azure cdn

### DIFF
--- a/src/shared/providers/StorageProvider/implementations/AzureStorageProvider.ts
+++ b/src/shared/providers/StorageProvider/implementations/AzureStorageProvider.ts
@@ -29,25 +29,21 @@ class AzureStorageProvider implements IStorageProvider {
 
     async saveFile(file: string): Promise<string> {
       const originalPath = path.resolve(UploadConfig.tmpFolder, file);
-      const promisseFile = new Promise((resolve, reject) => {
-        this.blobService.createBlockBlobFromLocalFile(
-          this.containerName,
-          file,
-          originalPath,
-          (err, result) => {
-            if (!err) {
-              return resolve(result)
+      
+      this.blobService.createBlockBlobFromLocalFile(
+         this.containerName,
+         file,
+         originalPath,
+         (err, result) => {
+            if (err) {
+               console.error(err)
             }
-            return reject(err)
-          },
-        )
-      });
-
+         },
+      )
+      
       await fs.promises.unlink(originalPath);
 
-      return Promise
-        .resolve(promisseFile)
-        .then(() => file)
+      return file;
     }
 
     async deleteFile(file: string): Promise<void> {


### PR DESCRIPTION
No método (saveFile) possuía uma rotina de deletar o arquivo, porém o arquivo era deletado antes da promisse de enviar o arquivo para o azure ser concluida.
Resolução - tirar a tratativa de promisses para envio do arquivo para a azure, porém isso pode ser melhorado com a utilização de promisses para executar as tarefas em uma ordem correta.